### PR TITLE
Fix inconsistency in variable naming (import section)

### DIFF
--- a/content/doc.md
+++ b/content/doc.md
@@ -59,7 +59,7 @@ In addition, if the import statement has media queries specified in it, imported
 Imported "library.less":
 
 ```less
-@imported-color: red;
+@importedColor: red;
 h1 { color: green; }
 ```
 


### PR DESCRIPTION
Tiny typo fix to make naming consistent with the examples that follow
