### PR TITLE
Minor fixes for usage page.

### DIFF
--- a/content/usage/online-less-compilers.md
+++ b/content/usage/online-less-compilers.md
@@ -1,4 +1,4 @@
-# Online less compilers
+# Online Less compilers
 
 ### [less2css.org](http://less2css.org/)
 > Online Integrated Development Environment (IDE) that is hosted in a browser allowing users to edit and compile LESS to CSS in real-time.
@@ -18,7 +18,7 @@
 ### [leafo.net/lessphp/editor](http://leafo.net/lessphp/editor.html)
 > [lessphp](http://leafo.net/lessphp/) live demo.
 
-## Online Web IDEs/Playgrounds with LESS support
+## Online Web IDEs/Playgrounds with Less support
 
 ### [jsFiddle]( http://jsfiddle.net)
 > Online Web Editor

--- a/content/usage/using-node.md
+++ b/content/usage/using-node.md
@@ -1,4 +1,4 @@
-## Using less in Node 
+## Using Less in Node 
 ### Installing lessc
 `npm install less --save-dev` and npm will install the latest official version of lessc in your project folder, adding it to your `package.json` devDependencies.
 

--- a/templates/includes/nav-usage.hbs
+++ b/templates/includes/nav-usage.hbs
@@ -1,16 +1,17 @@
 <li>
-  <a href="#using-less-environments">Using less - environment specifics</a>
+  <a href="#using-less-environments">Using Less - environment specifics</a>
   <ul class="nav">
     <li><a href="#using-less-in-node">Node</a></li>
     <li><a href="#using-less-in-the-browser">Browser</a></li>
     <li><a href="#browser-support">Browser Support</a></li>
-    <li><a href="#online-less-compilers">Online less compilers</a></li>
-    <li><a href="#guis-for-less">GUIs for less</a></li>
+    <li><a href="#online-less-compilers">Online Less compilers</a></li>
+    <li><a href="#online-web-ides-playgrounds-with-less-support">Online Web IDEs</a></li>
+    <li><a href="#guis-for-less">GUIs for Less</a></li>
     <li><a href="#third-party-compilers">Third party compilers</a></li>
   </ul>
 </li>
 <li>
-  <a href="#frameworks-using-less">Frameworks using less</a>
+  <a href="#frameworks-using-less">Frameworks using Less</a>
 </li>
 <li>
   <a href="#options">Options</a>


### PR DESCRIPTION
- Added missing 'online web IDEs' menu
- Changed `LESS` and `less` to `Less` where applicable.

btw, @lukepage, is this correct? I was using `LESS` before but now I see you actually use `Less` there.
