### PR TITLE
Fixes Incorrect LTE Operator

### DIFF
--- a/content/features/loops.md
+++ b/content/features/loops.md
@@ -32,7 +32,7 @@ A generic example of using a recursive loop to generate CSS grid classes:
 ```less
 .generate-columns(4);
 
-.generate-columns(@n, @i: 1) when (@i <= @n) {
+.generate-columns(@n, @i: 1) when (@i =< @n) {
   .column-@{i} {
     width: (@i * 100% / @n);
   }


### PR DESCRIPTION
The LTE operator for LESS is =<, not <=. The example code causes an "expected expression" error.
