### PR TITLE
Link to the right file of "Parent Selectors"

### DIFF
--- a/data/features.yml
+++ b/data/features.yml
@@ -50,7 +50,7 @@ published:
 
   parent-selectors:
     title: Parent Selectors
-    content: content/features/parent-selectors.md
+    content: content/features/Parent-Selectors.md
 
 
 # =============================================


### PR DESCRIPTION
I was checking the website (lesscss.org) yesterday. I saw than "Parent Selectors" didn't have any content. That is because in  "data/feature.yml" the link to the file is incorrect.
