### PR TITLE
Remove `-moz-` prefix for `box-shadow`

### DIFF
--- a/content/home/getting-started.md
+++ b/content/home/getting-started.md
@@ -13,7 +13,6 @@ For example:
 
 .box-shadow(@style, @c) when (iscolor(@c)) {
   -webkit-box-shadow: @style @c;
-  -moz-box-shadow:    @style @c;
   box-shadow:         @style @c;
 }
 .box-shadow(@style, @alpha: 50%) when (isnumber(@alpha)) {
@@ -35,7 +34,6 @@ compiles to
 }
 .box div {
   -webkit-box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
-  -moz-box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
 }
 ```


### PR DESCRIPTION
Only Firefox 3 requires `-moz-` prefix for `box-shadow`, so adding `-moz-` to `box-shadow` is such a bad example.
