### PR TITLE
fixed &pi; entity inside code block

### DIFF
--- a/content/functions/math-functions.md
+++ b/content/functions/math-functions.md
@@ -270,7 +270,7 @@ Output:
 
 ### pi
 
-> Returns π (pi);
+> Returns &pi; (pi);
 
 Parameters: `none`
 


### PR DESCRIPTION
In your documentation you used the `&pi;` entity inside code blocks. I just replaced them with the actual character when necessary.
