### PR TITLE
Removed ambiguity in wording on variables and namespaces.

### DIFF
--- a/content/features-overview.md
+++ b/content/features-overview.md
@@ -198,7 +198,7 @@ Using them is pretty straightforward. The following example uses percentage to c
 
 (Not to be confused with [CSS `@namespace`](http://www.w3.org/TR/css3-namespace/) or [namespace selectors](http://www.w3.org/TR/css3-selectors/#typenmsp)).
 
-Sometimes, you may want to group your variables or mixins, for organizational purposes, or just to offer some encapsulation. You can do this pretty intuitively in Less, say you want to bundle some mixins and variables under `#bundle`, for later reuse or distributing:
+Sometimes, you may want to group your mixins, for organizational purposes, or just to offer some encapsulation. You can do this pretty intuitively in Less, say you want to bundle some mixins and variables under `#bundle`, for later reuse or distributing:
 
 ```less
 #bundle {
@@ -224,6 +224,7 @@ Now if we want to mixin the `.button` class in our `#header a`, we can do:
 }
 ```
 
+Note that variables declared within a namespace will be scoped to that namespace only and will not be available outside of the scope via the same syntax that you would use to reference a mixin (`#Namespace > .mixin-name`). So, for example, you can't do the following: (`#Namespace > @this-will-not-work`).
 
 ### Scope
 


### PR DESCRIPTION
See http://stackoverflow.com/questions/8658270/less-css-syntax-error-when-referencing-variable-from-namespace
