### PR TITLE
Spelling error correction

### DIFF
--- a/content/features/extend.md
+++ b/content/features/extend.md
@@ -156,7 +156,7 @@ tr .bucket,
 
 
 ### Exact Matching with Extend
-Extend by default looks for exact match between selectors. It does matter whether selector uses leading start or not. It does not matter that two nth-expressions have the same meaning, they need to have to same form in order to be matched. The only exception are quotes in attribute selector, less knows they have the same meaning and matches them.
+Extend by default looks for exact match between selectors. It does matter whether selector uses leading star or not. It does not matter that two nth-expressions have the same meaning, they need to have to same form in order to be matched. The only exception are quotes in attribute selector, less knows they have the same meaning and matches them.
 
 Example:
 


### PR DESCRIPTION
In the "Exact Matching with Extend" section, "leading start" should be "leading star."
