### PR TITLE
Change "mediaQuery" to "mediaquery" in documentation

### DIFF
--- a/content/usage/using-less-in-the-browser.md
+++ b/content/usage/using-less-in-the-browser.md
@@ -25,9 +25,9 @@ less.modifyVars({
 ### Debugging
 It is possible to output rules in your CSS which allow tools to locate the source of the rule.
 
-Either specify the option `dumpLineNumbers` as above or add `!dumpLineNumbers:mediaQuery` to the url.
+Either specify the option `dumpLineNumbers` as above or add `!dumpLineNumbers:mediaquery` to the url.
 
-You can use the "comments" option with [FireLESS](https://addons.mozilla.org/en-us/firefox/addon/fireless/) and the "mediaQuery" option with FireBug/Chrome dev tools (it is identical to the SCSS media query debugging format).
+You can use the "comments" option with [FireLESS](https://addons.mozilla.org/en-us/firefox/addon/fireless/) and the "mediaquery" option with FireBug/Chrome dev tools (it is identical to the SCSS media query debugging format).
 
 ## Client-side Usage
 
@@ -66,12 +66,12 @@ Whether to request the import files with the async option or not. See fileAsync.
 
 ### dumpLineNumbers
 Type: `String`
-Options: ``|`comments`|`mediaQuery`|`all`
+Options: ``|`comments`|`mediaquery`|`all`
 Default: ``
 
 When set this outputs source line information directly into the output css file. This helps you debug where a particular rule came from.
 
-The comments option is used for outputting user understandable content, whilst mediaQuery is for use with a firefox extension which parses the css and extracts out the information.
+The comments option is used for outputting user understandable content, whilst mediaquery is for use with a firefox extension which parses the css and extracts out the information.
 
 In the future we hope this option to be superseded by sourcemaps.
 


### PR DESCRIPTION
less.js supports outputting source maps to a media query with the option
less.dumpLineNumbers set to "mediaquery". However, the documentation
incorrectly states that this option is to be set to "mediaQuery". Fix
it.
