### PR TITLE
Updated detached rulesets and mixins as functions

### DIFF
--- a/content/features/detached-rulesets.md
+++ b/content/features/detached-rulesets.md
@@ -2,7 +2,29 @@
 
 Released [v1.7.0]({{ less.master }}CHANGELOG.md)
 
-You may want to define a mixin that will abstract out either wrapping a piece of code in a media query or a non supported browser class name. You can now pass rulesets to mixins so that the mixin can wrap the content. E.g.
+Detached ruleset is a group of css properties, nested rulestes, media declarations or anything else stored in a variable. You can include it into a ruleset or another structure and all its properties are going to be copied there. You can also use it as a mixin argument and pass it around as any other variable.
+
+Simple example:
+````less
+// declare detached ruleset
+@detached-ruleset: { background: red; };
+
+// use detached ruleset
+.top {
+    @detached-ruleset(); 
+}
+````
+
+compiles into:
+````css
+.top {
+  background: red;
+}
+````
+
+Parentheses after detached ruleset call are mandatory. The `@detached-ruleset;` call would NOT work.
+
+It is usefull when you want to define a mixin that abstracts out either wrapping a piece of code in a media query or a non supported browser class name. The rulesets can be passed to mixin so that the mixin can wrap the content. E.g.
 
 ```less
 .desktop-and-old-ie(@rules) {
@@ -69,3 +91,144 @@ which will output
   }
 }
 ```
+
+Detached ruleset call unlocks (returns) all its mixins into caller the same way as mixin calls do. However, it does NOT return variables.
+
+Returned mixin:
+````less
+// detached ruleset with a mixin
+@detached-ruleset: { 
+    .mixin() {
+        color:blue;
+    }
+};
+// call detached ruleset
+.caller {
+    @detached-ruleset(); 
+    .mixin();
+}
+````
+
+Results in:
+````css
+.caller {
+  color: blue;
+}
+````
+
+Private variables:
+````less
+detached-ruleset: { 
+    @color:blue; //this variable is private
+};
+.caller {
+    color: @color; //syntax error
+}
+````
+
+## Scoping
+Detached ruleset can use all variables and mixins accessible on place where it is *defined* and where it is *called*. Otherwise said, both definition and caller scopes are available to it. If both scopes contains the same variable or mixin, declaration scope value takes precedence. 
+
+*Declaration scope* is the one where detached ruleset body is defined. Copying  detached ruleset from one variable into another can not modify its scope. Ruleset does not gain access to new scopes just by being referenced there.
+
+Lastly, detached ruleset can gain access to scope by being unlocked (imported) into it.
+
+#### Definition and Caller Scope Visibility
+Detached mixin sees callers variables and mixins:
+````less
+@detached-ruleset: {
+  caller-variable: @callerVariable; // variable is undefined here
+  .callerMixin(); // mixin is undefined here
+};
+
+selector {
+  // use detached ruleset
+  @detached-ruleset(); 
+
+  // define variable and mixin needed inside the detached ruleset
+  @callerVariable: value;
+  .callerMixin() {
+    variable: declaration;
+  }
+}
+````
+
+compiles into:
+````css
+selector {
+  caller-variable: value;
+  variable: declaration;
+}
+````
+
+Variable and mixins accessible form definition win over those available in caller:
+````less
+@variable: global;
+@detached-ruleset: {
+  //will use global variable, because it is accessible
+  //from detached-ruleset definition
+  variable: @variable; 
+};
+
+selector {
+  @detached-ruleset();
+  @variable: value; //variable defined in caller - will be ignored
+}
+````
+
+compiles into:
+````css
+selector {
+  variable: global;
+}
+````
+
+#### Referencing WONT Modify Detached Ruleset Scope
+Ruleset does not gain access to new scopes just by being referenced there:
+````less
+@detached-1: { scope-detached: @one @two; };
+.one {
+  @one: visible;
+  .two {
+    @detached-2: @detached-1; // copying/renaming ruleset 
+    @two: visible; // ruleset can not see this variable
+  }
+}
+
+.usePlace {
+  .one > .two(); 
+  @detached-2();
+}
+````
+
+throws an error:
+````
+ERROR 1:32 The variable "@one" was not declared.
+````
+
+#### Unlocking WILL Modify Detached Ruleset Scope
+Detached ruleset gains access by being unlocked (imported) inside a scope:
+````less
+#space {
+  .importer1() {
+    @detached: { scope-detached: @variable; }; // define detached ruleset
+  }
+}
+
+.importer2() {
+  @variable: value; // unlocked detached ruleset CAN see this variable
+  #space > .importer1(); // unlock/import detached ruleset
+}
+
+.usePlace {
+  .importer2(); // unlock/import detached ruleset second time
+   @detached();
+}
+````
+
+compiles into:
+````css
+.usePlace {
+  scope-detached: value;
+}
+````

--- a/content/features/mixins-as-functions.md
+++ b/content/features/mixins-as-functions.md
@@ -1,6 +1,6 @@
-> Return variables from mixins
+> Return variables or mixins from mixins
 
-All variables defined in a mixin are visible and can be used in caller's scope (unless the caller scope already has a variable with same name defined, including previously defined by another mixin call).
+Variables and mixins defined in a mixin are visible and can be used in caller's scope. There is only one exception, variable is not copied if the caller contains a variable with the same name (that includes variables defined by another mixin call).  Only variables present in callers local scope are protected. Variables inherited from parent scopes are overridden.
 
 Example:
 
@@ -48,3 +48,50 @@ div {
   padding: 33px;
 }
 ```
+<<<<<<< HEAD
+=======
+
+Variable defined directly in callers scope can not be overriden. However, variable defined in callers parent scope is not protected and will be overriden:
+````less
+.mixin() {
+  @size: in-mixin; 
+  @definedOnlyInMixin: in-mixin;
+}
+
+.class {
+  margin: @size @definedOnlyInMixin;
+  .mixin(); 
+}
+
+@size: globaly-defined-value; // callers parent scope - no protection
+````
+
+Results in:
+````css
+.class {
+  margin: in-mixin in-mixin;
+}
+````
+
+Finally, mixin defined in mixin acts as return value too:
+````less
+.unlock(@value) { // outer mixin
+  .doSomething() { // nested mixin
+    declaration: @value;
+  }
+}
+
+#namespace {
+  .unlock(5); // unlock doSomething mixin
+  .doSomething(); //nested mixin was copied here and is usable 
+}
+````
+
+Results in:
+````css
+#namespace {
+  declaration: 5;
+}
+````
+
+>>>>>>> f945fa6948c69b5a84e402bc8eb8b2ead2735cfa


### PR DESCRIPTION
This pull request is add things we discussed in https://github.com/less/less.js/issues/2085, https://github.com/less/less.js/issues/2083 and https://github.com/less/less.js/issues/2064 .

Added few details about detached rulesets:
- short introduction with simplest possible example,
- return values from detached rulesets,
- scoping - which variables are seen from inside detached rulesets.

Added few details about mixins as functions:
- they return also mixins,
- local scope protection.
