### PR TITLE
Update doc: using-less-in-the-browser.md

### DIFF
--- a/content/usage/using-less-in-the-browser.md
+++ b/content/usage/using-less-in-the-browser.md
@@ -66,8 +66,8 @@ Whether to request the import files with the async option or not. See fileAsync.
 
 ### dumpLineNumbers
 Type: `String`
-Options: ``|`comments`|`mediaquery`|`all`
-Default: ``
+Options: `''`| `'comments'`|`'mediaquery'`|`'all'`
+Default: `''`
 
 When set this outputs source line information directly into the output css file. This helps you debug where a particular rule came from.
 


### PR DESCRIPTION
dumpLineNumbers options where poorly displayed (because of empty inline block : ``)
