### PR TITLE
Clarification on the behavior of --source-map-less-inline command-line option

### DIFF
--- a/content/usage/command-line-usage.md
+++ b/content/usage/command-line-usage.md
@@ -220,7 +220,7 @@ This is the opposite of the rootpath option, it specifies a path which should be
 lessc --source-map-less-inline
 ```
 
-This option specifies that we should include all of the css files in to the sourcemap. This means that you only need your map file to get to your original source.
+This option specifies that we should include all of the Less files in to the sourcemap. This means that you only need your map file to get to your original source.
 
 This can be used in conjunction with the map inline option so that you do not need to have any additional external files at all.
 


### PR DESCRIPTION
Fixes an inaccuracy that made it difficult to understand the behavior of this option.
