### PR TITLE
Fix broken links pointing to GitHub

### DIFF
--- a/content/functions/string-functions.md
+++ b/content/functions/string-functions.md
@@ -91,7 +91,7 @@ format-s-upper: "repetitions: 3 file: directory%2Ffile.less";
 
 > Replaces a text within a string.
 
-Released [v1.7.0]({{ less.master }}/CHANGELOG.md)
+Released [v1.7.0]({{ less.master }}CHANGELOG.md)
 
 Parameters:
 

--- a/content/usage/developing-less.md
+++ b/content/usage/developing-less.md
@@ -2,7 +2,7 @@
 title: Developing Less
 ---
 
-Thanks for thinking about contributing. Please read the [contributing instructions]({{ less.master }}/CONTRIBUTING.md) carefully to avoid wasted work.
+Thanks for thinking about contributing. Please read the [contributing instructions]({{ less.master }}CONTRIBUTING.md) carefully to avoid wasted work.
 
 ## Install these tools
 

--- a/data/_utils/extend-pkg.js
+++ b/data/_utils/extend-pkg.js
@@ -1,7 +1,7 @@
 module.exports = {
   repo: "https://github.com/less/less.js.git",
   issues: "https://github.com/less/less.js/issues",
-  master: "https://github.com/less/less.js/blob/master",
-  rawmaster: "https://raw.github.com/less/less.js/master/dist",
+  master: "https://github.com/less/less.js/blob/master/",
+  rawmaster: "https://raw.github.com/less/less.js/master/dist/",
   sourcearchive: "https://github.com/less/less.js/archive/v"
 };

--- a/data/less.json
+++ b/data/less.json
@@ -88,7 +88,7 @@
   ],
   "repo": "https://github.com/less/less.js.git",
   "issues": "https://github.com/less/less.js/issues",
-  "master": "https://github.com/less/less.js/blob/master",
-  "rawmaster": "https://raw.github.com/less/less.js/master/dist",
+  "master": "https://github.com/less/less.js/blob/master/",
+  "rawmaster": "https://raw.github.com/less/less.js/master/dist/",
   "sourcearchive": "https://github.com/less/less.js/archive/v"
 }

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -36,7 +36,7 @@ lead: "Learn about the history of Less, meet the core team, and check out the ev
 
   </div>
   <p>Get involved with Less.js development by <a href="{{less.issues}}/new">opening an issue</a> or submitting a pull request (if it's a feature request, please open an issue first). </p>
-  <p>Read our <a href="{{ less.master }}/CONTRIBUTING.md">contributing guidelines</a> and the <a href="{{rel 'usage'}}/#developing-less">developing section</a> of our usage page.</p>
+  <p>Read our <a href="{{ less.master }}CONTRIBUTING.md">contributing guidelines</a> and the <a href="{{rel 'usage'}}/#developing-less">developing section</a> of our usage page.</p>
 </div>
 
 

--- a/templates/includes/banner.hbs
+++ b/templates/includes/banner.hbs
@@ -2,7 +2,7 @@
   <div class="container">
     less v{{less.version}} has been released -
     <strong>
-      <a href="{{less.master}}/CHANGELOG.md">See what's new</a>
+      <a href="{{less.master}}CHANGELOG.md">See what's new</a>
     </strong>
   </div>
 </div>

--- a/templates/includes/footer.hbs
+++ b/templates/includes/footer.hbs
@@ -14,10 +14,10 @@
       <li class="muted">&middot;</li>
       <li><a href="{{ site.issues }}">Less Docs Issues</a></li>
       <li class="muted">&middot;</li>
-      <li><a href="{{ less.master }}/CHANGELOG.md">Changelog</a></li>
+      <li><a href="{{ less.master }}CHANGELOG.md">Changelog</a></li>
       {{#is links.releases true}}
       <li class="muted">&middot;</li>
-      <li><a href="{{ less.master }}/dist/">Releases</a>Blog</a></li>
+      <li><a href="{{ less.master }}dist/">Releases</a>Blog</a></li>
       {{/is}}
     </ul>
   </div>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -35,7 +35,7 @@ lead: "An overview of Less, how to download and use, examples and more."
   </div>
 
   <h2 id="browser-downloads">Browser downloads</h2>
-  <a class="btn btn-default" href="{{ less.rawmaster }}/less-{{ less.version }}.min.js">Download Less.js v{{less.version}}</a>
+  <a class="btn btn-default" href="{{ less.rawmaster }}less-{{ less.version }}.min.js">Download Less.js v{{less.version}}</a>
 
   <div class="docs-dl-options">
     {{md 'download-options'}}
@@ -86,5 +86,5 @@ lead: "An overview of Less, how to download and use, examples and more."
       </ul>
     </div>
   </div>
-  <p>The full Less.js license is located <a href="{{ less.master }}/LICENSE">in the project repository</a> for more information.</p>
+  <p>The full Less.js license is located <a href="{{ less.master }}LICENSE">in the project repository</a> for more information.</p>
 </div>


### PR DESCRIPTION
It seems like 2ec20ce228b removed a trailing slash from the `less.master` template variable. This broke some links, like ones to the changelog:

``` md
Released [v1.7.0]({{ less.master }}CHANGELOG.md)
```

which lost a slash and rendered like:

``` html
<p>Released <a href="https://github.com/less/less.js/blob/masterCHANGELOG.md">v1.7.0</a></p>
```

This commit re-adds the trailing slash to `less.master` to fix those links, and undoes a couple of spot changes that others have made to fix individual links (like #202).

`less.rawmaster` also had a trailing slash added, but this was just to increase similarity with `less.master`, not to fix any broken links.
