### PR TITLE
Fix link to programmatic usage

### DIFF
--- a/content/usage/v2-upgrade.md
+++ b/content/usage/v2-upgrade.md
@@ -28,7 +28,7 @@ Programmatic Usage
 ------------------
 
 We have deprecated the use of less.Parser and toCss to generate the css. Instead we require you to use the `less.render` shorthand.
-See (Programmatic Usage)[#programmatic-usage] for more information.
+See [Programmatic Usage](#programmatic-usage) for more information.
 
 If you already use `less.render` you should not require any changes.
 


### PR DESCRIPTION
The md for the link was round the wrong way.
