### PR TITLE
Updated gulp-less note on `sourceMap`s for gulp-less 1.3.6 (the current version)

### DIFF
--- a/content/usage/third-party-compilers.md
+++ b/content/usage/third-party-compilers.md
@@ -6,7 +6,7 @@ title: Third-party compilers
 
 * **[grunt-contrib-less](https://github.com/gruntjs/grunt-contrib-less)**
 * **[assemble-less](https://github.com/assemble/assemble-less)**: Full-featured Grunt.js plugin for compiling Less files to CSS, with additional options for maintaining libraries of Less components and themes. For advanced users, this plugin allows you to define and manage Less "packages" or "bundles" using JSON, [Lo-dash](https://github.com/bestiejs/lodash)(underscore) templates (e.g. `<%= bootstrap.less %>`), and [node-glob](https://github.com/isaacs/node-glob) / [minimatch](https://github.com/isaacs/minimatch) (e.g. `'../src/**/*.less"`). _assemble-less_ also has a number of options including minifying CSS
-* **[gulp-less](https://github.com/plus3network/gulp-less)**: Please note that this plugin only generates inline sourcemaps (with `sourceMap: true`) - specifying a `sourceMapFilename` option will do nothing.
+* **[gulp-less](https://github.com/plus3network/gulp-less)**: Please note that this plugin discards `source-map` options, opting to instead using the [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps) library.
 * **[RECESS](https://github.com/twitter/recess)**: Twitter's code quality tool for CSS built on top of Less. RECESS has options for compiling Less to CSS, as well as linting, formatting and minifying CSS.
 * **[autoless](https://github.com/jgonera/autoless)**: A Less files watcher, with dependency tracking (changes to imported files cause other files to be updated too) and growl notifications.
 * **[Connect Middleware for Less.js](https://github.com/emberfeather/less.js-middleware)**: Connect Middleware for Less.js compiling


### PR DESCRIPTION
• Made it clearer that gulp-less just doesn't support LESS's source-maps, and mentioned/linked to gulp-sourcemaps.
    » As of gulp-less 1.3.6, none of LESS's source-map options are supported (AFAICT from reading its docs).  The gulp-less-recommended avenue is to use gulp-sourcemaps for both inline and external source maps.