### PR TITLE
Fix indent in parent selector

### DIFF
--- a/content/features/parent-selectors.md
+++ b/content/features/parent-selectors.md
@@ -175,9 +175,9 @@ The selector `.no-borderradius &` will prepend `.no-borderradius` to its parent 
 
 ```less
 p, a, ul, li {
-border-top: 2px dotted #366;
+  border-top: 2px dotted #366;
   & + & {
-      border-top: 0;
+    border-top: 0;
   }
 }
 ```


### PR DESCRIPTION
Small indent fix in the last "Combinatorial explosion" example.
