### PR TITLE
broken link to usage

### DIFF
--- a/templates/usage.hbs
+++ b/templates/usage.hbs
@@ -8,7 +8,7 @@ lead: "How to use less server-side, client-side and with third parties."
 =================================== -->
 <div class="docs-section">
   <h1 id="using-less-environments">Using Less</h1>
-  <p class="lead">Using less in node, browser and third party. For general installation instructions and an overview, please read the <a href="{{resolve 'index'}}/#using-less">Using Less</a> section on our front page.</p>
+  <p class="lead">Using less in node, browser and third party. For general installation instructions and an overview, please read the <a href="/#using-less">Using Less</a> section on our front page.</p>
 </div>
 
 


### PR DESCRIPTION
There's a link in the docs on this page [usage](http://lesscss.org/usage/#using-less) that uses `<a href="{{resolve 'index'}}/#using-less">` within [usage.hbs](https://github.com/less/less-docs/blob/master/templates/usage.hbs#L11). That link should be rendering `http://lesscss.org/#using-less` but it's rendering `http://lesscss.org/index.html/#using-less`. Since it's rendering to `index.html` and it's not removing the `path.extname` I can assume that It's because it's not finding it in resolves `pages` loop. I'm not sure how to fix it with `hbs`. But this does the trick. 