### PR TITLE
Update using-less-in-the-browser.md

### DIFF
--- a/content/usage/using-less-in-the-browser.md
+++ b/content/usage/using-less-in-the-browser.md
@@ -85,7 +85,7 @@ It is possible to output rules in your CSS which allow tools to locate the sourc
 
 Either specify the option `dumpLineNumbers` as above or add `!dumpLineNumbers:mediaquery` to the url.
 
-You can use the `comments` option with [FireLESS](https://addons.mozilla.org/en-us/firefox/addon/fireless/) and the `mediaquery` option with FireBug/Chrome dev tools (it is identical to the SCSS media query debugging format).
+You can use the `mediaquery` option with [FireLESS](https://addons.mozilla.org/en-us/firefox/addon/fireless/) (it is identical to the SCSS media query debugging format). Also see [FireLess and Less v2](http://bassjobsen.weblogs.fm/fireless-less-v2/). The `comment` option can be used to display file information and line numbers in the inline compiled CSS code.
 
 ### Options
 


### PR DESCRIPTION
FireLess also uses the mediaquery format. As far as i understand neither chrome or Firebug (without FireLess) supports the format, see also: http://stackoverflow.com/questions/25408595/debugging-less-with-less-js-and-media-sass-debug-info-in-chrome-or-firefox/27954478