### PR TITLE
Added IRC channel to docs

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -50,6 +50,7 @@ lead: "Learn about the history of Less, meet the core team, and check out the ev
   <ul>
     <!--li>Read and subscribe to <a href="">The Official Less.js Blog</a>.</li -->
     <li>Have a feature request or bug report? <a href="{{ less.issues }}">Let us know on our GitHub Issues</a>.</li>
+    <li>Join the ##lesscss channel on Freenode to help others learn Less. Webchat available <a href="http://webchat.freenode.net/?randomnick=1&channels=%23%23lesscss">here</a>.</li>
   </ul>
 </div>
 


### PR DESCRIPTION
There is a ##lesscss channel on Freenode for helping people with Less, and we want to let the community know about it. 

This is the only place I could find in the docs that mentioned other places for help. If there's another place, let me know and I'll update this