### PR TITLE
add Ionic plugin

### DIFF
--- a/content/usage/plugins.md
+++ b/content/usage/plugins.md
@@ -70,6 +70,7 @@ Preprocess plugins which preload library's Less code:
  - [Flexbox grid from flexboxgrid.com for less.js](https://github.com/bassjobsen/less-plugin-flexboxgrid) 
  - [Flexible Grid System (flexible.gs) for less.js ](https://github.com/bassjobsen/less-plugin-flexiblegs)
  - [Cardinal CSS for less.js](https://github.com/bassjobsen/less-plugin-cardinal)
+ - [Ionic for less.js](https://github.com/bassjobsen/less-plugin-ionic)
 
 For plugin authors
 --------------------------


### PR DESCRIPTION
Imports the Less code for Ionic Framework before your custom Less code. Ionic is a beautiful, open source front-end SDK for developing hybrid mobile apps with HTML5.