### PR TITLE
Fix <version> in using-less.md

### DIFF
--- a/content/home/using-less.md
+++ b/content/home/using-less.md
@@ -81,8 +81,8 @@ See the [Usage]({{resolve 'usage'}}) section for details of other tools.
 > Each less.js release contains also rhino-compatible version.
 
 Command line rhino version requires two files:
-* less-rhino-<version>.js - compiler implementation,
-* lessc-rhino-<version>.js - command line support.
+* less-rhino-&lt;version&gt;.js - compiler implementation,
+* lessc-rhino-&lt;version&gt;.js - command line support.
 
 Command to run the compiler:
 ````


### PR DESCRIPTION
Currently, &lt;version&gt; in the filenames in Rhino section is incorrectly parsed as an HTML tag and thus not displayed by the browser. Replacing < and > with &amp;lt; and &amp;gt; fixes the problem.