### PR TITLE
Added HTMLKit Tools

### DIFF
--- a/content/usage/editors-and-plugins.md
+++ b/content/usage/editors-and-plugins.md
@@ -17,6 +17,7 @@ Also see: [GUIs for Less.js](#guis-for-less)
 * [CodeLobster][codelobster] (built-in [syntax highlighting][codelobster-sh])
 * [KineticWing IDE][kineticwing] (built-in [support][kineticwing-less])
 * [nodeMirror](https://www.npmjs.org/package/node-mirror) (built-in support, built-in HTML/CSS/Less preview)
+* [HTML-Kit Tools](http://www.htmlkit.com/tools/) (built-in support)
 
 ### [Sublime Text 2 & 3](http://sublimetext.com/)
 


### PR DESCRIPTION
HTMLKit Tools is an IDE that natively support LESS