### PR TITLE
Update broken Crunch app image and description

### DIFF
--- a/content/usage/guis-for-less.md
+++ b/content/usage/guis-for-less.md
@@ -8,13 +8,13 @@ _This page focuses on GUI compilers. For command line usage and tools see [Comma
 
 ## Cross platform
 
-### [Crunch!](http://crunchapp.net/)
+### [Crunch 2!](http://getcrunch.co/)
 
-> Crunch is not just a Less compiler, it is also a Less editor for Windows and Mac.
+> The editor and compiler for awesome people.
 
-If you work a lot with Less files, you should definitely try it out. Crunch is built on the Adobe AIR platform. Get more info: [http://crunchapp.net/](http://crunchapp.net/).
+Crunch 2 is a cross-platform (Windows, Mac, and Linux) editor with integrated compiling. If you work with large Less projects, you should definitely try it out, as you only need the free version for Less files. Available at: [http://getcrunch.co/](http://getcrunch.co/).
 
-![Crunch screenshot](http://crunchapp.net/wp-content/themes/crunch/img/screenshot2.png)
+<img title="Crunch screenshot" src="http://getcrunch.co/wp-content/uploads/2015/10/crunch_retina2.jpg" width="600" height="411" />
 
 
 ### [Mixture](http://mixture.io/)


### PR DESCRIPTION
Noticed that Crunch had a broken image the other day, so here's a new one.