### PR TITLE
Clarify paths option

### DIFF
--- a/content/usage/command-line-usage.md
+++ b/content/usage/command-line-usage.md
@@ -87,7 +87,7 @@ lessc --include-path=PATH1;PATH2
 
 Sets available include paths. Separated by ':' or ';' on Windows.
 
-Use this to configure a list of paths which less will use to find imports in. You might use this for instance to specify a path to a library which you want to be referenced simply and relatively in the less files.
+If the file in an `@import` rule does not exist at that exact location, less will look for it at the location(s) passed to this option. You might use this for instance to specify a path to a library which you want to be referenced simply and relatively in the less files.
 
 In node, set a paths option
 ```js


### PR DESCRIPTION
The language explaining the `paths` option is a little ambiguous. I interpreted it as "less will look for the `@import` files at the locations provided to `include-path`". But after [viewing the source](https://github.com/less/less.js/blob/59c012c16a71eca2fd9f354b8db8fffaa5e14d6d/lib/less-node/file-manager.js#L38) I now realize less *first* looks for the file at the absolute path specified by the `@import` rule and it only looks in the `include-path` locations if it's not found at the absolute path.

This PR clarifies this in the docs.