### PR TITLE
Update guis-for-less.md

### DIFF
--- a/content/usage/guis-for-less.md
+++ b/content/usage/guis-for-less.md
@@ -17,17 +17,6 @@ Crunch 2 is a cross-platform (Windows, Mac, and Linux) editor with integrated co
 ![Crunch screenshot](http://getcrunch.co/wp-content/uploads/2015/10/crunch_retina2.jpg)
 
 
-### [Mixture](http://mixture.io/)
-
-> A rapid prototyping and static site generation tool for designers and developers
-
-Mixture brings together a collection of awesome tools and best practices. It's quick, no-fuss, super-powerful and works with your favourite editor.
-
-Get more info: [http://mixture.io/](http://mixture.io)
-
-![mixture screenshot](https://s3.amazonaws.com/mixture-mixed/1/775/assets/img/img1.jpg)
-
-
 ### [SimpLESS](http://wearekiss.com/simpless)
 
 > SimpLESS is a minimalistic Less compiler. Just drag, drop and compile.


### PR DESCRIPTION
Removed Mixture because its developing was suspended. Rading official website is clearly written: "he time has come for us to turn off the download and recommend that users investigate alternatives, we highly recommend you try Gulp or Grunt"
