### PR TITLE
Update detached-rulesets.md

### DIFF
--- a/content/features/detached-rulesets.md
+++ b/content/features/detached-rulesets.md
@@ -122,6 +122,7 @@ Private variables:
     @color:blue; // this variable is private
 };
 .caller {
+    @detached-ruleset();
     color: @color; // syntax error
 }
 ````


### PR DESCRIPTION
Fix documents.
Mixin is missing a step to call a detached ruleset.
I think first unlocked a detached ruleset, we can try to call variable  ‘@ color’.

>
Private variables:
````less
@detached-ruleset: { 
    @color:blue; // this variable is private
};
.caller {
    @detached-ruleset();        // Suggest adding this sentence
    color: @color; // syntax error
}
````