### PR TITLE
Add sass2less as a less preprocessor plugin

### DIFF
--- a/content/usage/plugins.md
+++ b/content/usage/plugins.md
@@ -63,6 +63,11 @@ List of Less Plugins
   * invent something to use instead of `import Bla-bla`, `import Blee-bloo`
 -->
 
+#### Preprocessors
+| | |
+|---|---|
+| [sass2less](https://github.com/mediafreakch/less-plugin-sass2less) | Convert SASS to LESS or import SASS files into your .less files and re-use varialbes, mixins and more 
+
 #### Postprocessor/Feature Plugins
 | | |
 |---|---|


### PR DESCRIPTION
Hi,

I created a less-plugin that lets you convert `.scss` files to `.less` or import SASS files directly into your LESS files. Would you be so kind to link it in your docs?

Edi