### PR TITLE
Clarify trailing semicolon - this tripped me up

### DIFF
--- a/content/features/detached-rulesets.md
+++ b/content/features/detached-rulesets.md
@@ -7,7 +7,7 @@ A detached ruleset is a group of css properties, nested rulesets, media declarat
 Simple example:
 ````less
 // declare detached ruleset
-@detached-ruleset: { background: red; };
+@detached-ruleset: { background: red; }; // <-- this trailing semicolon ; is mandatory
 
 // use detached ruleset
 .top {


### PR DESCRIPTION
Normally, CSS properties are written with `selector { prop: value }` syntax, *without* trailing semicolon.  When I made my first ruleset, this didn't occur to me.  And the errors didn't really help me either.. Took a few minutes to figure it out.