### PR TITLE
Fix bad relative hyperlink to features page

### DIFF
--- a/content/functions/misc-functions.md
+++ b/content/functions/misc-functions.md
@@ -384,7 +384,7 @@ div {
 }
 ```
 
-Notes: A boolean expression supported as the `conditional` parameter are the same as of [Guard Statements](features/#mixins-feature-mixin-guards-feature).
+Notes: A boolean expression supported as the `conditional` parameter are the same as of [Guard Statements](/features/#mixins-feature-mixin-guards-feature).
 Note however that any boolean expression for the `condition` parameter require an extra set of parens:
 ```less
 if((2 > 1), blue, green); // OK


### PR DESCRIPTION
Apologies if this is incorrect; I think it's accurate based on the assemble-generated paths on the actual web site, ignoring the very broken github markdown viewer paths.