### PR TITLE
fixed code examples in mixins-aliasing.md

### DIFF
--- a/content/features/mixins-aliasing.md
+++ b/content/features/mixins-aliasing.md
@@ -37,12 +37,12 @@ Entire mixin calls can be aliased and called as variable calls. As in:
 
 ```less
 #library() {
-  .rules() {
+  .colors() {
     background: green;
   }
 }
 .box {
-  @alias: #library.rules();
+  @alias: #library.colors();
   @alias();
 }
 ```
@@ -57,7 +57,7 @@ Note, unlike mixins used in root, mixin calls assigned to variables and _called 
 
 ```less
 #library() {
-  .rules() {
+  .colors() {
     background: green;
   }
 }


### PR DESCRIPTION
On line 65, the example referenced `#library.colors` instead of `#library.rules` which would have been a more valid example of the parentheses requirement. Reviewed the other examples and concluded that all examples should use `colors` instead of `rules`.