### PR TITLE
Add svelte-preprocess to Tools section

### DIFF
--- a/content/tools/preprocessors.md
+++ b/content/tools/preprocessors.md
@@ -1,0 +1,7 @@
+---
+title: Preprocessors
+---
+
+## Preprocessors
+
+* [`svelte-preprocess`](https://github.com/sveltejs/svelte-preprocess/blob/main/docs/preprocessing.md#less) (converts Less to CSS before passing to the Svelte compiler)

--- a/content/tools/preprocessors.md
+++ b/content/tools/preprocessors.md
@@ -1,7 +1,0 @@
----
-title: Preprocessors
----
-
-## Preprocessors
-
-* [`svelte-preprocess`](https://github.com/sveltejs/svelte-preprocess/blob/main/docs/preprocessing.md#less) (converts Less to CSS before passing to the Svelte compiler)

--- a/content/tools/third-party-compilers.md
+++ b/content/tools/third-party-compilers.md
@@ -2,12 +2,11 @@
 title: Third Party Compilers
 ---
 
-## Node.js Compilers
+## Node.js Tools
 
 * **[grunt-contrib-less](https://github.com/gruntjs/grunt-contrib-less)**
-* **[assemble-less](https://github.com/assemble/assemble-less)**: Full-featured Grunt.js plugin for compiling Less files to CSS, with additional options for maintaining libraries of Less components and themes. For advanced users, this plugin allows you to define and manage Less "packages" or "bundles" using JSON, [Lo-dash](https://github.com/bestiejs/lodash)(underscore) templates (e.g. `<%= bootstrap.less %>`), and [node-glob](https://github.com/isaacs/node-glob) / [minimatch](https://github.com/isaacs/minimatch) (e.g. `'../src/**/*.less"`). _assemble-less_ also has a number of options including minifying CSS
 * **[gulp-less](https://github.com/plus3network/gulp-less)**: Please note that this plugin discards `source-map` options, opting to instead using the [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps) library.
-* **[autoless](https://github.com/jgonera/autoless)**: A Less files watcher, with dependency tracking (changes to imported files cause other files to be updated too) and growl notifications.
+* **[`svelte-preprocess`](https://github.com/sveltejs/svelte-preprocess/blob/main/docs/preprocessing.md#less) (converts Less to CSS before passing it to the Svelte compiler)
 * **[Connect Middleware for Less](https://github.com/emberfeather/less.js-middleware)**: Connect Middleware for Less compiling
 
 


### PR DESCRIPTION
There didn't seem to be a good existing section for this, so I made a new one. Do I need to link it from anywhere? I didn't see `editors-and-plugins` referenced anywhere, so I was assuming it'd be included automatically