### PR TITLE
chore: not support IE11 anymore

### DIFF
--- a/content/usage/using-less-in-the-browser.md
+++ b/content/usage/using-less-in-the-browser.md
@@ -65,7 +65,7 @@ Or for brevity they can be set as attributes on the script and link tags:
 
 ### Browser Support
 
-Less.js supports all modern browsers (recent versions of Chrome, Firefox, Safari, IE11+, and Edge). While it is possible to use Less on the client side in production, please be aware that there are performance implications for doing so (although the latest releases of Less are quite a bit faster). Also, sometimes cosmetic issues can occur if a JavaScript error occurs. This is a trade off of flexibility vs. speed. For the fastest performance possible for a static web site, we recommend compiling Less on the server side.
+Less.js supports all modern browsers (recent versions of Chrome, Firefox, Safari, and Edge). While it is possible to use Less on the client side in production, please be aware that there are performance implications for doing so (although the latest releases of Less are quite a bit faster). Also, sometimes cosmetic issues can occur if a JavaScript error occurs. This is a trade off of flexibility vs. speed. For the fastest performance possible for a static web site, we recommend compiling Less on the server side.
 
 There are reasons to use client-side less in production, such as if you want to allow users to tweak variables which will affect the theme and you want to show it to them in real-time - in this instance a user is not worried about waiting for a style to update before seeing it.
 


### PR DESCRIPTION
IE11 support should have been removed at least as of Less 4, Try to fix https://github.com/less/less-docs/issues/554