### PR TITLE
feat: keep h* id attribute for algolia

### DIFF
--- a/templates/_plugins/navigation.js
+++ b/templates/_plugins/navigation.js
@@ -115,15 +115,15 @@ module.exports = function navigationPlugin(params, callback) {
         var $e = $(e);
         var id = $e.attr('id');
 
-        // // Anchor template
+        // Anchor template
         var anchor = template(anchorTemplate, {
             id: id
         });
         $(this).prepend(anchor);
 
         // Adjust heading
-        $(this).removeAttr('id').addClass('docs-heading');
-        // $(this).addClass('docs-heading');
+        // $(this).removeAttr('id').addClass('docs-heading');
+        $(this).addClass('docs-heading');
 
         // if ($(this).prev().children().hasClass('source-link')) {
         //     var sourceLink = $(this).prev().children('.source-link');


### PR DESCRIPTION
> https://docsearch.algolia.com/docs/tips#add-anchors-to-headings
> When using headings (as mentioned above), you should also try to add a custom anchor to each of them. Anchors are specified by HTML attributes (name or id) added to headers that allow browsers to directly scroll to the right position in the page. They're accessible by clicking a link with # followed by the anchor.
DocSearch will honor such anchors and automatically bring your users to the anchor closest to the search result they selected.

```diff
-      $(this).removeAttr('id').addClass('docs-heading');
+      $(this).addClass('docs-heading');
```

After Change:

<img width="1280" alt="less-docs" src="https://user-images.githubusercontent.com/14012511/174483642-87e5a060-3ea9-402b-916d-3f990f601c2f.png">
