### PR TITLE
feat(docs): added fomantic-ui to framework list

### DIFF
--- a/content/tools/frameworks-using-less.md
+++ b/content/tools/frameworks-using-less.md
@@ -13,6 +13,7 @@ notes: Entreaty for contributors. Please filter out all purely advertising and n
 | [Bootswatch](http://bootswatch.com/) | Collection of free themes for Bootstrap |
 | [Cardinal](http://cardinalcss.com/) | Small "mobile first" CSS framework for front-end developers who build responsive web applications |
 | [Flat UI Free](http://designmodo.com/flat-free/) | Theme and framework for Bootstrap |
+| [Fomantic-UI](https://www.fomantic-ui.com/) | The official community fork of Semantic-UI |
 | [Ink](http://ink.sapo.pt/) | set of tools for quick development of web interfaces |
 | [Metro UI CSS](http://metroui.org.ua/) | Set of styles to create a site with an interface similar to Windows 8 |
 | [Petal](http://http://shakrmedia.github.io/petal/) | A modern, light CSS UI framework developed at Shakr |

--- a/content/tools/frameworks-using-less.md
+++ b/content/tools/frameworks-using-less.md
@@ -13,7 +13,7 @@ notes: Entreaty for contributors. Please filter out all purely advertising and n
 | [Bootswatch](http://bootswatch.com/) | Collection of free themes for Bootstrap |
 | [Cardinal](http://cardinalcss.com/) | Small "mobile first" CSS framework for front-end developers who build responsive web applications |
 | [Flat UI Free](http://designmodo.com/flat-free/) | Theme and framework for Bootstrap |
-| [Fomantic-UI](https://www.fomantic-ui.com/) | The official community fork of Semantic-UI |
+| [Fomantic-UI](https://fomantic-ui.com/) | The official community fork of Semantic-UI |
 | [Ink](http://ink.sapo.pt/) | set of tools for quick development of web interfaces |
 | [Metro UI CSS](http://metroui.org.ua/) | Set of styles to create a site with an interface similar to Windows 8 |
 | [Petal](http://http://shakrmedia.github.io/petal/) | A modern, light CSS UI framework developed at Shakr |


### PR DESCRIPTION
## Description

Fomantic-UI took over active development of SUI in 2018 and since then made use of LESS features for dynamic compilation of many classes for colors or sizing, which SUI still has hardcoded.