### PR TITLE
Fix typo in detached-rulesets.md

### DIFF
--- a/content/features/detached-rulesets.md
+++ b/content/features/detached-rulesets.md
@@ -127,7 +127,7 @@ Private variables:
 ````
 
 ## Scoping
-A detached ruleset can use all variables and mixins accessible where it is *defined* and where it is *called*. Otherwise said, both definition and caller scopes are available to it. If both scopes contains the same variable or mixin, declaration scope value takes precedence. 
+A detached ruleset can use all variables and mixins accessible where it is *defined* and where it is *called*. Otherwise said, both definition and caller scopes are available to it. If both scopes contain the same variable or mixin, declaration scope value takes precedence. 
 
 *Declaration scope* is the one where detached ruleset body is defined. Copying a detached ruleset from one variable into another cannot modify its scope. The ruleset does not gain access to new scopes just by being referenced there.
 


### PR DESCRIPTION
The sentence:

> If both scopes **contains** the same...

Should read:

> If both scopes **contain** the same...