### PR TITLE
Add Copy Code Feature and Open Link in New Tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3589,7 +3589,8 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
       "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/liftup": {
       "version": "3.0.1",
@@ -8557,7 +8558,8 @@
           "version": "0.3.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
           "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/templates/includes/docs-header.hbs
+++ b/templates/includes/docs-header.hbs
@@ -7,7 +7,7 @@
 
       <p>Use with Node.js:</p>
   
-  <code id="codeSnippet">npm install -g less <i class="fas fa-copy" style="color:#428bca;cursor:pointer" onclick="copyCode()"></i></code><br/>
+      <code id="codeSnippet">npm install -g less <i class="fas fa-copy" style="color:#428bca;cursor:pointer" onclick="copyCode()" title="Copy Command to Clip Board"></i></code><br/>
       <code>&gt; lessc styles.less styles.css</code>
       <br><br>
       <p>Or the browser:</p>
@@ -19,40 +19,5 @@
     </div>
   </div>
 </div>
-
-  <!-- Include the JavaScript code to copy the code snippet -->
-  <script>
-    function copyCode() {
-      // Get the code snippet element
-      var codeElement = document.getElementById("codeSnippet");
-
-      // Create a textarea element and set its value to the code snippet
-      var textarea = document.createElement("textarea");
-      textarea.value = codeElement.innerText;
-
-      // Append the textarea element to the document
-      document.body.appendChild(textarea);
-
-      // Select the content of the textarea
-      textarea.select();
-
-      // Copy the selected text to the clipboard
-      document.execCommand("copy");
-
-      // Remove the textarea element from the document
-      document.body.removeChild(textarea);
-
-      // Provide some visual feedback to the user
-// Show a beautiful message using Toastr
-      toastr.success("Command copied to clipboard!", "Success", {
-        closeButton: true,
-        progressBar: true,
-        positionClass: "toast-bottom-left",
-        timeOut: 4000,
-      });    }
-  </script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
-
 {{!-- Callout for the old docs link --}}
 {{> banner }}

--- a/templates/includes/docs-header.hbs
+++ b/templates/includes/docs-header.hbs
@@ -12,9 +12,9 @@
       <br><br>
       <p>Or the browser:</p>
       <code>{{marked '<link rel="stylesheet/less" type="text/css" href="styles.less" />' }}</code><br>
-      <code>&lt;script src="<a href="{{ site.cdn.cloudflare }}">{{ site.cdn.cloudflare }}</a>" &gt;&lt;/script&gt;</code><br>
+      <code>&lt;script src="<a href="{{ site.cdn.cloudflare }}" >{{ site.cdn.cloudflare }}</a>" &gt;&lt;/script&gt;</code><br>
       <br><br>
-      <p>Or try <code><a href="{{ site.playground }}">the online playground</a></code> ! 🆕</p>
+      <p>Or try <code><a href="{{ site.playground }}" target="blank">the online playground</a></code> ! 🆕</p>
 
     </div>
   </div>

--- a/templates/includes/docs-header.hbs
+++ b/templates/includes/docs-header.hbs
@@ -6,7 +6,8 @@
       <h3>It's CSS, with just a little more.</h3>
 
       <p>Use with Node.js:</p>
-      <code>npm install -g less</code><br>
+  
+  <code id="codeSnippet">npm install -g less <i class="fas fa-copy" style="color:#428bca;cursor:pointer" onclick="copyCode()"></i></code><br/>
       <code>&gt; lessc styles.less styles.css</code>
       <br><br>
       <p>Or the browser:</p>
@@ -18,6 +19,40 @@
     </div>
   </div>
 </div>
+
+  <!-- Include the JavaScript code to copy the code snippet -->
+  <script>
+    function copyCode() {
+      // Get the code snippet element
+      var codeElement = document.getElementById("codeSnippet");
+
+      // Create a textarea element and set its value to the code snippet
+      var textarea = document.createElement("textarea");
+      textarea.value = codeElement.innerText;
+
+      // Append the textarea element to the document
+      document.body.appendChild(textarea);
+
+      // Select the content of the textarea
+      textarea.select();
+
+      // Copy the selected text to the clipboard
+      document.execCommand("copy");
+
+      // Remove the textarea element from the document
+      document.body.removeChild(textarea);
+
+      // Provide some visual feedback to the user
+// Show a beautiful message using Toastr
+      toastr.success("Command copied to clipboard!", "Success", {
+        closeButton: true,
+        progressBar: true,
+        positionClass: "toast-bottom-left",
+        timeOut: 4000,
+      });    }
+  </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 
 {{!-- Callout for the old docs link --}}
 {{> banner }}

--- a/templates/includes/head.hbs
+++ b/templates/includes/head.hbs
@@ -1,20 +1,39 @@
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="{{default description site.description}}">
-<meta name="author" content="The Core Less Team">
+<meta charset="utf-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="description" content="{{default description site.description}}" />
+<meta name="author" content="The Core Less Team" />
 
 <title>
-  {{default title (titleize basename)}} | {{site.title}}
+  {{default title (titleize basename)}}
+  |
+  {{site.title}}
 </title>
+<!-- Include Font Awesome CSS -->
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+/>
 
-<link href="https://fonts.googleapis.com/css?family=Noto+Serif|Oxygen" rel="stylesheet">
+<!-- Include Toastr CSS and JS -->
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css"
+/>
+
+<link
+  href="https://fonts.googleapis.com/css?family=Noto+Serif|Oxygen"
+  rel="stylesheet"
+/>
 
 <!-- Algolia DocSearch styles -->
-<link rel="stylesheet" href="https://fastly.jsdelivr.net/npm/@docsearch/css@3"/>
+<link
+  rel="stylesheet"
+  href="https://fastly.jsdelivr.net/npm/@docsearch/css@3"
+/>
 
 <!-- Main styles -->
-<link href="{{ assets }}/css/index.css" rel="stylesheet">
+<link href="{{assets}}/css/index.css" rel="stylesheet" />
 
 <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!--[if lt IE 9]>
@@ -23,4 +42,4 @@
 <![endif]-->
 
 <!-- Favicons -->
-<link rel="shortcut icon" href="{{ assets }}/ico/favicon.ico">
+<link rel="shortcut icon" href="{{assets}}/ico/favicon.ico" />

--- a/templates/includes/javascripts.hbs
+++ b/templates/includes/javascripts.hbs
@@ -11,8 +11,29 @@
     debug: false // Set debug to true if you want to inspect the modal
   });
 </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <script src="//code.jquery.com/jquery-1.10.2.min.js"></script>
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
+
+
+<!-- Include the JavaScript code to copy the code snippet -->
+<script>
+    function copyCode() {
+      var codeElement = document.getElementById("codeSnippet");
+      var textarea = document.createElement("textarea");
+      textarea.value = codeElement.innerText;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      toastr.success("Command copied to clipboard!", "Success", {
+        closeButton: true,
+        progressBar: true,
+        positionClass: "toast-bottom-left",
+        timeOut: 4000,
+      });    }
+</script>
 
 {{#live}}<script src="http://platform.twitter.com/widgets.js"></script>{{/live}}
 <script src="//cdnjs.cloudflare.com/ajax/libs/holder/2.2.0/holder.min.js"></script>


### PR DESCRIPTION
Hey there!

I've added a new feature to our code snippet section that allows users to copy the code to their clipboard. Additionally, I've made some improvements by opening the link in a new tab for a better user experience.

**Here's a summary of the changes:**

1. Added a copy icon to code snippet, making it easier for users to copy the code.
2. Implemented the copy functionality using JavaScript, enabling users to click the copy icon and have the code copied to their clipboard.
3. Styling improvements for the copy icon to make it more visually appealing.
4. Modified the link behavior to open in a new tab using the `target="blank"` attribute.

I've thoroughly tested these changes and ensured compatibility with different browsers.

Please review the code and let me know if you have any feedback or suggestions. I believe these enhancements will greatly improve the user experience and make it easier for users to utilize the code examples.

Thank you for your time and consideration!

Best regards,
Fizan Iqbal