### PR TITLE
Update Russian translation link

### DIFF
--- a/data/translations.yml
+++ b/data/translations.yml
@@ -30,7 +30,7 @@
   url: http://giovanneafonso.github.io/lesscss.org/
   
 - language: Russian
-  url: http://less-lang.info
+  url: https://lesscss.ru
 
 - language: Spanish
   url: http://amatellanes.github.io/lesscss.org/


### PR DESCRIPTION
The current Russian translation link on the About page points to http://less-lang.info, which no longer resolves.

This updates it to https://lesscss.ru.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Russian translation resource URL to a more current address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->